### PR TITLE
Bring sitemap.xml generation in-house

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ gem "puma", "~> 5.5"
 
 gem "reverse_markdown", "~> 2.1"
 
-gem "bridgetown-sitemap", "~> 1.1", :group => :bridgetown_plugins
 gem "bridgetown-feed", "~> 2.1", :group => :bridgetown_plugins
 
 gem "dotenv", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,6 @@ GEM
       bridgetown (>= 1.0.0.alpha5, < 2.0)
     bridgetown-paginate (1.0.0.beta2)
       bridgetown-core (= 1.0.0.beta2)
-    bridgetown-sitemap (1.1.1)
-      bridgetown (>= 0.20, < 2.0)
     builder (3.2.4)
     cloudinary (1.21.0)
       aws_cf_signer
@@ -180,7 +178,6 @@ DEPENDENCIES
   bridgetown (~> 1.0.0.beta2)
   bridgetown-cloudinary (~> 1.2)
   bridgetown-feed (~> 2.1)
-  bridgetown-sitemap (~> 1.1)
   dotenv (~> 2.7)
   minitest
   minitest-profile

--- a/src/_pages/sitemap.xml
+++ b/src/_pages/sitemap.xml
@@ -10,8 +10,8 @@ no_index: true
   {% unless res.layout == blank and layout == blank %}
   <url>
     <loc>{{ res.absolute_url }}</loc>
-    <lastmod>{{ res.last_modified_at }}</lastmod>
+    <lastmod>{{ res.last_modified_at | date: "%Y-%m-%d" }}</lastmod>
   </url>
-  {% end unless %}
+  {% endunless %}
   {% endfor %}
 </urlset>

--- a/src/_pages/sitemap.xml
+++ b/src/_pages/sitemap.xml
@@ -1,0 +1,17 @@
+---
+permalink: /sitemap.xml
+layout: none
+no_index: true
+---
+
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for res in site.resources %}
+  {% unless res.layout == blank and layout == blank %}
+  <url>
+    <loc>{{ res.absolute_url }}</loc>
+    <lastmod>{{ res.last_modified_at }}</lastmod>
+  </url>
+  {% end unless %}
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
The sitemap plugin is making content generation take up to 5-7x as long. Bringing the sitemap.xml generation in-house slims down the process substantially.

From:
```
[Bridgetown]             Done! 🎉 Completed in less than 7.65 seconds.
```

To:

```
[Bridgetown]             Done! 🎉 Completed in less than 0.89 seconds.
```