### PR TITLE
Define buildpack list and order in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,17 @@
       "size": "hobby"
     }
   },
+  "buildpacks": [
+    {
+      "url": "https://github.com/edmorley/heroku-buildpack-timestamps"
+    },
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/ruby"
+    }
+  ],
   "image": "heroku/ruby",
   "environments": {
     "test": {


### PR DESCRIPTION
We need this in order for Review Apps in the Heroku pipeline to know which buildpacks to pick up and in which order.