### PR TITLE
Define buildpack list and order in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,17 @@
       "size": "hobby"
     }
   },
+  "buildpacks": [
+    {
+      "url": "https://github.com/edmorley/heroku-buildpack-timestamps"
+    },
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/ruby"
+    }
+  ],
   "image": "heroku/ruby",
   "environments": {
     "test": {


### PR DESCRIPTION
In order for the Heroku pipeline review apps to build properly from scratch, we need to define the buildpack list within `app.json`.