### PR TITLE
[wip] Use Rack::Rewrite to redirect www to non-www

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,6 +4,11 @@ require "bridgetown-core/rack/boot"
 require 'rack/rewrite'
 
 use Rack::Rewrite do
+  # Redirect from www to non-www
+  r301 %r{.*}, 'https://johnathan.org$&', :if => Proc.new {|rack_env|
+    rack_env['SERVER_NAME'] != 'www.johnathan.org'
+  }
+
   # Redirect http to https when in production and using the Heroku-hosted app
   if ENV['BRIDGETOWN_ENV'] == "production" && ENV['HOST_ENV'] == "heroku"
     r301 %r{.*}, 'https://jdotorg.herokuapp.com$&', :scheme => 'http'

--- a/config.ru
+++ b/config.ru
@@ -6,7 +6,7 @@ require 'rack/rewrite'
 use Rack::Rewrite do
   # Redirect from www to non-www
   r301 %r{.*}, 'https://johnathan.org$&', :if => Proc.new {|rack_env|
-    rack_env['SERVER_NAME'] == 'www.johnathan.org'
+    rack_env['REQUEST_URI'] ~ /www.johnathan.org/
   }
 
   # Redirect http to https when in production and using the Heroku-hosted app

--- a/config.ru
+++ b/config.ru
@@ -6,7 +6,7 @@ require 'rack/rewrite'
 use Rack::Rewrite do
   # Redirect from www to non-www
   r301 %r{.*}, 'https://johnathan.org$&', :if => Proc.new {|rack_env|
-    rack_env['SERVER_NAME'] != 'www.johnathan.org'
+    rack_env['SERVER_NAME'] == 'www.johnathan.org'
   }
 
   # Redirect http to https when in production and using the Heroku-hosted app

--- a/config.ru
+++ b/config.ru
@@ -6,7 +6,7 @@ require 'rack/rewrite'
 use Rack::Rewrite do
   # Redirect from www to non-www
   r301 %r{.*}, 'https://johnathan.org$&', :if => Proc.new {|rack_env|
-    rack_env['REQUEST_URI'] ~ /www.johnathan.org/
+    rack_env['REQUEST_URI'] =~ /www.johnathan.org/
   }
 
   # Redirect http to https when in production and using the Heroku-hosted app


### PR DESCRIPTION
This PR uses Rack::Rewrite to redirect `www.johnathan.org` to `johnathan.org`. This is a replacement for commit `c8a2b472f14e7a1d97ab0deee722100aca705ad3` that broke the app.