### PR TITLE
Purge Bunny.net CDN on release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bin/bridgetown start
+release: rake cache:purge

--- a/Rakefile
+++ b/Rakefile
@@ -45,19 +45,24 @@ namespace :cache do
   desc "Purge Bunny.net CDN cache"
   task :purge => :dotenv do
     puts "Purging the CDN cache"
-    url = URI("https://api.bunny.net/pullzone/#{ENV['BUNNY_ZONE_ID']}/purgeCache")
 
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = true
+    if ENV['REVIEW'] != 'true'
+      url = URI("https://api.bunny.net/pullzone/#{ENV['BUNNY_ZONE_ID']}/purgeCache")
 
-    request = Net::HTTP::Post.new(url)
-    request["AccessKey"] = ENV['BUNNY_API_KEY']
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
 
-    response = http.request(request)
-    if response.code != "204"
-      raise "Unexpected response from CDN. Expected 204, got #{response.code}\n Response body: #{response.body}"
+      request = Net::HTTP::Post.new(url)
+      request["AccessKey"] = ENV['BUNNY_API_KEY']
+
+      response = http.request(request)
+      if response.code != "204"
+        raise "Unexpected response from CDN. Expected 204, got #{response.code}\n Response body: #{response.body}"
+      end
+      puts "Cache purged"
+    else
+      puts "Skipping. In review app."
     end
-    puts "Cache purged"
   end
 end
 


### PR DESCRIPTION
Creating a Rake task to purge the Bunny CDN on release to ensure content changes are picked up.