### PR TITLE
Fix bug where URLs for links didn't render

### DIFF
--- a/src/_pages/links.md
+++ b/src/_pages/links.md
@@ -24,7 +24,7 @@ Collections of links for things I find interesting on the Internet, broken out b
       </div>
       <div class="col-sm-10">
         <div class="card-body">
-          <h5 class="card-title"><a href="{{ item.url }}"
+          <h5 class="card-title"><a href="{{ item.link }}"
               target="_blank">{{ item.title }}</a></h5>
         </div>
       </div>


### PR DESCRIPTION
The tag `{{ item.url }}` was incorrect. Should be `{{ item.link }}`